### PR TITLE
Fixed ttclid cookie value

### DIFF
--- a/template.js
+++ b/template.js
@@ -13,7 +13,7 @@ const containerVersion = getContainerVersion();
 const isDebug = containerVersion.debugMode;
 const eventData = getAllEventData();
 
-let ttclid = getCookieValues('_ttclid')[0];
+let ttclid = getCookieValues('ttclid')[0];
 if (!ttclid) ttclid = eventData._ttclid;
 if (!ttclid) {
     let url = eventData.page_location;


### PR DESCRIPTION
Based on TikTok documentation they use `ttclid` for the key name, not `_ttclid`: https://ads.tiktok.com/marketing_api/docs?rid=4eezrhr6lg4&id=1701890980108353