### PR TITLE
Add support for Big Query logging

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
   "singleQuote": true,
+  "trailingComma": "none",
   "printWidth": 1000
 }

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ It can be used to track conversion events, collect custom audiences, dynamic pro
 
 ## How to use TikTok tag
 
-TikTok event API tag for server GTM allows sending user data (email, phone number, user ID, user IP, and user agent), properties, objects, and event parameters.
-It automatically transforms required information lowercase and hash using SHA256.
+The **TikTok Events API tag for GTM Server Side** allows sending user data (email, phone number, user ID, user IP, and user agent), properties, objects, and event parameters.
+It automatically converts the required information to lowercase and hashes it using SHA-256.
 
 - More about the [TikTok Events API](https://ads.tiktok.com/marketing_api/docs?rid=959icq5stjr&id=1701890979375106).
 - Detailed description of the [TikTok event API tag for the GTM server](https://stape.io/how-to-set-up-tiktok-events-api/)
@@ -15,7 +15,7 @@ It automatically transforms required information lowercase and hash using SHA256
 ### Getting started
 
 1. Add TikTok events API tag to the Google Tag Manager server container.
-2. Use the TikTok developers account to create App ID and API Access token.
+2. Use the TikTok developers account to create an App ID and an API Access token.
 3. Add required parameters to the TikTok events API tag inside the server GTM.
 
 More detailed description of setting up the [TikTok events API tag in the sGTM](https://stape.io/how-to-set-up-tiktok-events-api/).
@@ -36,7 +36,8 @@ More detailed description of setting up the [TikTok events API tag in the sGTM](
 - SubmitForm
 - CompleteRegistration
 - Subscribe
+- PageView
 
 ## Open Source
 
-TikTok Events API Tag for GTM Server Side is developing and maintained by [Stape Team](https://stape.io/) under the Apache 2.0 license.
+The **TikTok Events API Tag for GTM Server Side** is developed and maintained by [Stape Team](https://stape.io/) under the Apache 2.0 license.

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,5 +1,7 @@
 homepage: "https://stape.io/"
 versions:
+  - sha: 86867d5dcc275ea314995aec8df83fc3d20ce177
+    changeNotes: Add support for BigQuery logging.
   - sha: 3f0a634ab1082886bdf8667a37d99bc4a008548e
     changeNotes: Added Page View event
   - sha: 6f6d47d9011bc247df34b08c0bafcd45d11fe3de

--- a/template.tpl
+++ b/template.tpl
@@ -611,6 +611,73 @@ ___TEMPLATE_PARAMETERS___
         "defaultValue": "debug"
       }
     ]
+  },
+  {
+    "displayName": "BigQuery Logs Settings",
+    "name": "bigQueryLogsGroup",
+    "groupStyle": "ZIPPY_CLOSED",
+    "type": "GROUP",
+    "subParams": [
+      {
+        "type": "RADIO",
+        "name": "bigQueryLogType",
+        "radioItems": [
+          {
+            "value": "no",
+            "displayValue": "Do not log to BigQuery"
+          },
+          {
+            "value": "always",
+            "displayValue": "Log to BigQuery"
+          }
+        ],
+        "simpleValueType": true,
+        "defaultValue": "no"
+      },
+      {
+        "type": "GROUP",
+        "name": "logsBigQueryConfigGroup",
+        "groupStyle": "NO_ZIPPY",
+        "subParams": [
+          {
+            "type": "TEXT",
+            "name": "logBigQueryProjectId",
+            "displayName": "BigQuery Project ID",
+            "simpleValueType": true,
+            "help": "Optional.  \u003cbr\u003e\u003cbr\u003e  If omitted, it will be retrieved from the environment variable \u003cI\u003eGOOGLE_CLOUD_PROJECT\u003c/i\u003e where the server container is running. If the server container is running on Google Cloud, \u003cI\u003eGOOGLE_CLOUD_PROJECT\u003c/i\u003e will already be set to the Google Cloud project\u0027s ID."
+          },
+          {
+            "type": "TEXT",
+            "name": "logBigQueryDatasetId",
+            "displayName": "BigQuery Dataset ID",
+            "simpleValueType": true,
+            "valueValidators": [
+              {
+                "type": "NON_EMPTY"
+              }
+            ]
+          },
+          {
+            "type": "TEXT",
+            "name": "logBigQueryTableId",
+            "displayName": "BigQuery Table ID",
+            "simpleValueType": true,
+            "valueValidators": [
+              {
+                "type": "NON_EMPTY"
+              }
+            ]
+          }
+        ],
+        "enablingConditions": [
+          {
+            "paramName": "bigQueryLogType",
+            "paramValue": "always",
+            "type": "EQUALS"
+          }
+        ]
+      }
+    ]
   }
 ]
 
@@ -634,18 +701,20 @@ const getTimestampMillis = require('getTimestampMillis');
 const Math = require('Math');
 const makeInteger = require('makeInteger');
 const generateRandom = require('generateRandom');
+const BigQuery = require('BigQuery');
 
-const isLoggingEnabled = determinateIsLoggingEnabled();
-const traceId = isLoggingEnabled ? getRequestHeader('trace-id') : undefined;
+/**********************************************************************************************/
+
+const traceId = getRequestHeader('trace-id');
 const gtmVersion = 'stape_2_0_1';
 
 const eventData = getAllEventData();
-const url = eventData.page_location || getRequestHeader('referer');
 
 if (!isConsentGivenOrNotRequired()) {
   return data.gtmOnSuccess();
 }
 
+const url = eventData.page_location || getRequestHeader('referer');
 if (url && url.lastIndexOf('https://gtm-msr.appspot.com/', 0) === 0) {
   return data.gtmOnSuccess();
 }
@@ -672,21 +741,17 @@ if (url) {
 const apiVersion = '1.3';
 const postUrl = 'https://business-api.tiktok.com/open_api/v' + apiVersion + '/event/track/';
 const eventName = getEventName(eventData, data);
-let postBody = mapEvent(eventData, data);
+const postBody = mapEvent(eventData, data);
 
-if (isLoggingEnabled) {
-  logToConsole(
-    JSON.stringify({
-      Name: 'TikTok',
-      Type: 'Request',
-      TraceId: traceId,
-      EventName: eventName,
-      RequestMethod: 'POST',
-      RequestUrl: postUrl,
-      RequestBody: postBody,
-    })
-  );
-}
+log({
+  Name: 'TikTok',
+  Type: 'Request',
+  TraceId: traceId,
+  EventName: eventName,
+  RequestMethod: 'POST',
+  RequestUrl: postUrl,
+  RequestBody: postBody
+});
 
 if (ttclid) {
   setCookie('ttclid', ttclid, {
@@ -695,7 +760,7 @@ if (ttclid) {
     samesite: 'Lax',
     secure: true,
     'max-age': 2592000, // 30 days
-    httpOnly: false,
+    httpOnly: false
   });
 }
 
@@ -706,26 +771,23 @@ if (ttp) {
     samesite: 'Lax',
     secure: true,
     'max-age': 34190000, // 13 months
-    httpOnly: false,
+    httpOnly: false
   });
 }
 
 sendHttpRequest(
   postUrl,
   (statusCode, headers, body) => {
-    if (isLoggingEnabled) {
-      logToConsole(
-        JSON.stringify({
-          Name: 'TikTok',
-          Type: 'Response',
-          TraceId: traceId,
-          EventName: eventName,
-          ResponseStatusCode: statusCode,
-          ResponseHeaders: headers,
-          ResponseBody: body,
-        })
-      );
-    }
+    log({
+      Name: 'TikTok',
+      Type: 'Response',
+      TraceId: traceId,
+      EventName: eventName,
+      ResponseStatusCode: statusCode,
+      ResponseHeaders: headers,
+      ResponseBody: body
+    });
+
     if (!data.useOptimisticScenario) {
       if (statusCode >= 200 && statusCode < 400) {
         data.gtmOnSuccess();
@@ -737,9 +799,9 @@ sendHttpRequest(
   {
     headers: {
       'Content-Type': 'application/json',
-      'Access-Token': data.accessToken,
+      'Access-Token': data.accessToken
     },
-    method: 'POST',
+    method: 'POST'
   },
   JSON.stringify(postBody)
 );
@@ -748,11 +810,14 @@ if (data.useOptimisticScenario) {
   data.gtmOnSuccess();
 }
 
+/**********************************************************************************************/
+// Vendor related functions
+
 function mapEvent(eventData, data) {
-  let eventSource = data.eventSource || 'web';
+  const eventSource = data.eventSource || 'web';
   let mappedData = {
     event: eventName,
-    event_time: getEventTime(eventData),
+    event_time: getEventTime(eventData)
   };
 
   mappedData = addEventId(mappedData, eventData);
@@ -773,23 +838,15 @@ function mapEvent(eventData, data) {
   mappedData = addPropertiesData(eventData, mappedData);
   mappedData = hashDataIfNeeded(mappedData);
 
-  let requestData = {
+  const requestData = {
     event_source: eventSource,
     event_source_id: data.pixelId,
-    data: [mappedData],
+    data: [mappedData]
   };
   const testEventCode = eventData.test_event_code || data.testEventCode;
   if (testEventCode) requestData.test_event_code = testEventCode;
 
   return requestData;
-}
-
-function isHashed(value) {
-  if (!value) {
-    return false;
-  }
-
-  return makeString(value).match('^[A-Fa-f0-9]{64}$') !== null;
 }
 
 function hashData(value) {
@@ -814,7 +871,7 @@ function hashData(value) {
   }
 
   return sha256Sync(makeString(value).trim().toLowerCase(), {
-    outputEncoding: 'hex',
+    outputEncoding: 'hex'
   });
 }
 
@@ -853,7 +910,7 @@ function addPropertiesData(eventData, mappedData) {
     mappedData.properties.contents = [];
 
     eventData.items.forEach((d, i) => {
-      let item = {};
+      const item = {};
 
       if (d.price) item.price = d.price;
       if (d.quantity) item.quantity = d.quantity;
@@ -989,9 +1046,9 @@ function addUserData(eventData, mappedData, eventSource) {
 
 function getEventName(eventData, data) {
   if (data.eventType === 'inherit') {
-    let eventName = eventData.event_name;
+    const eventName = eventData.event_name;
 
-    let gaToEventName = {
+    const gaToEventName = {
       page_view: 'Pageview',
       click: 'ClickButton',
       download: 'Download',
@@ -1017,7 +1074,7 @@ function getEventName(eventData, data) {
       'gtm4wp.productClickEEC': 'ViewContent',
       'gtm4wp.checkoutOptionEEC': 'InitiateCheckout',
       'gtm4wp.checkoutStepEEC': 'AddPaymentInfo',
-      'gtm4wp.orderCompletedEEC': 'CompletePayment',
+      'gtm4wp.orderCompletedEEC': 'CompletePayment'
     };
 
     if (!gaToEventName[eventName]) {
@@ -1028,25 +1085,6 @@ function getEventName(eventData, data) {
   }
 
   return data.eventType === 'custom' ? data.eventNameCustom : data.eventName;
-}
-
-function determinateIsLoggingEnabled() {
-  const containerVersion = getContainerVersion();
-  const isDebug = !!(containerVersion && (containerVersion.debugMode || containerVersion.previewMode));
-
-  if (!data.logType) {
-    return isDebug;
-  }
-
-  if (data.logType === 'no') {
-    return false;
-  }
-
-  if (data.logType === 'debug') {
-    return isDebug;
-  }
-
-  return data.logType === 'always';
 }
 
 function addEventId(mappedData, eventData) {
@@ -1066,7 +1104,7 @@ function getEventTime(eventData) {
 
 function addPageData(mappedData, eventData) {
   mappedData.page = {
-    url: data.pageLocation || eventData.page_location,
+    url: data.pageLocation || eventData.page_location
   };
 
   if (data.pageReferrer) mappedData.page.referrer = data.pageReferrer;
@@ -1078,7 +1116,7 @@ function addPageData(mappedData, eventData) {
 
 function addAppData(mappedData, eventData) {
   mappedData.app = {
-    app_id: data.appId,
+    app_id: data.appId
   };
 
   if (data.appName) mappedData.app.app_name = data.appName;
@@ -1141,6 +1179,19 @@ function generateTtp() {
   return result;
 }
 
+/**********************************************************************************************/
+// Helpers
+
+function isHashed(value) {
+  if (!value) return false;
+  return makeString(value).match('^[A-Fa-f0-9]{64}$') !== null;
+}
+
+function isValidValue(value) {
+  const valueType = getType(value);
+  return valueType !== 'null' && valueType !== 'undefined' && value !== '';
+}
+
 function isConsentGivenOrNotRequired() {
   if (data.adStorageConsent !== 'required') return true;
   if (eventData.consent_state) return !!eventData.consent_state.ad_storage;
@@ -1148,9 +1199,95 @@ function isConsentGivenOrNotRequired() {
   return xGaGcs[2] === '1';
 }
 
-function isValidValue(value) {
-  const valueType = getType(value);
-  return valueType !== 'null' && valueType !== 'undefined' && value !== '';
+function log(rawDataToLog) {
+  const logDestinationsHandlers = {};
+  if (determinateIsLoggingEnabled()) logDestinationsHandlers.console = logConsole;
+  if (determinateIsLoggingEnabledForBigQuery()) logDestinationsHandlers.bigQuery = logToBigQuery;
+
+  // Key mappings for each log destination
+  const keyMappings = {
+    // No transformation for Console is needed.
+    bigQuery: {
+      Name: 'tag_name',
+      Type: 'type',
+      TraceId: 'trace_id',
+      EventName: 'event_name',
+      RequestMethod: 'request_method',
+      RequestUrl: 'request_url',
+      RequestBody: 'request_body',
+      ResponseStatusCode: 'response_status_code',
+      ResponseHeaders: 'response_headers',
+      ResponseBody: 'response_body'
+    }
+  };
+
+  for (const logDestination in logDestinationsHandlers) {
+    const handler = logDestinationsHandlers[logDestination];
+    if (!handler) continue;
+
+    const mapping = keyMappings[logDestination];
+    const dataToLog = mapping ? {} : rawDataToLog;
+    // Map keys based on the log destination
+    if (mapping) {
+      for (const key in rawDataToLog) {
+        const mappedKey = mapping[key] || key; // Fallback to original key if no mapping exists
+        dataToLog[mappedKey] = rawDataToLog[key];
+      }
+    }
+
+    handler(dataToLog);
+  }
+}
+
+function logConsole(dataToLog) {
+  logToConsole(JSON.stringify(dataToLog));
+}
+
+function logToBigQuery(dataToLog) {
+  const connectionInfo = {
+    projectId: data.logBigQueryProjectId,
+    datasetId: data.logBigQueryDatasetId,
+    tableId: data.logBigQueryTableId
+  };
+
+  // timestamp is required.
+  dataToLog.timestamp = getTimestampMillis();
+
+  // Columns with type JSON need to be stringified.
+  ['request_body', 'response_headers', 'response_body'].forEach((p) => {
+    const value = dataToLog[p];
+    // These types don't need to be stringified.
+    if (['string', 'null', 'undefined'].indexOf(getType(value)) === -1) dataToLog[p] = JSON.stringify(value);
+  });
+
+  // assertApi doesn't work for 'BigQuery.insert()'. It's needed to convert BigQuery into a function when testing.
+  // Ref: https://gtm-gear.com/posts/gtm-templates-testing/
+  const bigquery = getType(BigQuery) === 'function' ? BigQuery() /* Only during Unit Tests */ : BigQuery;
+  bigquery.insert(connectionInfo, [dataToLog], { ignoreUnknownValues: true });
+}
+
+function determinateIsLoggingEnabled() {
+  const containerVersion = getContainerVersion();
+  const isDebug = !!(containerVersion && (containerVersion.debugMode || containerVersion.previewMode));
+
+  if (!data.logType) {
+    return isDebug;
+  }
+
+  if (data.logType === 'no') {
+    return false;
+  }
+
+  if (data.logType === 'debug') {
+    return isDebug;
+  }
+
+  return data.logType === 'always';
+}
+
+function determinateIsLoggingEnabledForBigQuery() {
+  if (data.bigQueryLogType === 'no') return false;
+  return data.bigQueryLogType === 'always';
 }
 
 
@@ -1474,18 +1611,150 @@ ___SERVER_PERMISSIONS___
       "isEditedByUser": true
     },
     "isRequired": true
+  },
+  {
+    "instance": {
+      "key": {
+        "publicId": "access_bigquery",
+        "versionId": "1"
+      },
+      "param": [
+        {
+          "key": "allowedTables",
+          "value": {
+            "type": 2,
+            "listItem": [
+              {
+                "type": 3,
+                "mapKey": [
+                  {
+                    "type": 1,
+                    "string": "projectId"
+                  },
+                  {
+                    "type": 1,
+                    "string": "datasetId"
+                  },
+                  {
+                    "type": 1,
+                    "string": "tableId"
+                  },
+                  {
+                    "type": 1,
+                    "string": "operation"
+                  }
+                ],
+                "mapValue": [
+                  {
+                    "type": 1,
+                    "string": "*"
+                  },
+                  {
+                    "type": 1,
+                    "string": "*"
+                  },
+                  {
+                    "type": 1,
+                    "string": "*"
+                  },
+                  {
+                    "type": 1,
+                    "string": "write"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "clientAnnotations": {
+      "isEditedByUser": true
+    },
+    "isRequired": true
   }
 ]
 
 
 ___TESTS___
 
-scenarios: []
-setup: ''
+scenarios:
+- name: Should log to console, if the 'Always log to console' option is selected
+  code: "mockData.logType = 'always';\n\nconst expectedDebugMode = true;\nmock('getContainerVersion',\
+    \ () => {\n  return {\n    debugMode: expectedDebugMode\n  };\n}); \n\nmock('logToConsole',\
+    \ (logData) => {\n  const parsedLogData = JSON.parse(logData);\n  requiredConsoleKeys.forEach(p\
+    \ => assertThat(parsedLogData[p]).isDefined());\n});\n\nrunCode(mockData);\n\n\
+    assertApi('logToConsole').wasCalled();\n"
+- name: Should log to console, if the 'Log during debug and preview' option is selected
+    AND is on preview mode
+  code: |
+    mockData.logType = 'debug';
+
+    const expectedDebugMode = true;
+    mock('getContainerVersion', () => {
+      return {
+        debugMode: expectedDebugMode
+      };
+    });
+
+    mock('logToConsole', (logData) => {
+      const parsedLogData = JSON.parse(logData);
+      requiredConsoleKeys.forEach(p => assertThat(parsedLogData[p]).isDefined());
+    });
+
+    runCode(mockData);
+
+    assertApi('logToConsole').wasCalled();
+- name: Should NOT log to console, if the 'Log during debug and preview' option is
+    selected AND is NOT on preview mode
+  code: "mockData.logType = 'debug';\n\nconst expectedDebugMode = false;\nmock('getContainerVersion',\
+    \ () => {\n  return {\n    debugMode: expectedDebugMode\n  };\n}); \n\nrunCode(mockData);\n\
+    \nassertApi('logToConsole').wasNotCalled();\n"
+- name: Should NOT log to console, if the 'Do not log' option is selected
+  code: |
+    mockData.logType = 'no';
+
+    runCode(mockData);
+
+    assertApi('logToConsole').wasNotCalled();
+- name: Should log to BQ, if the 'Log to BigQuery' option is selected
+  code: "mockData.bigQueryLogType = 'always';\n\n// assertApi doesn't work for 'BigQuery.insert()'.\n\
+    // Ref: https://gtm-gear.com/posts/gtm-templates-testing/\nmock('BigQuery', ()\
+    \ => {\n  return { \n    insert: (connectionInfo, rows, options) => { \n     \
+    \ assertThat(connectionInfo).isDefined();\n      assertThat(rows).isArray();\n\
+    \      assertThat(rows).hasLength(1);\n      requiredBqKeys.forEach(p => assertThat(rows[0][p]).isDefined());\n\
+    \      assertThat(options).isEqualTo(expectedBqOptions);\n      return Promise.create((resolve,\
+    \ reject) => {\n        resolve();\n      });\n    }\n  };\n});\n\nrunCode(mockData);"
+- name: Should NOT log to BQ, if the 'Do not log to BigQuery' option is selected
+  code: "mockData.bigQueryLogType = 'no';\n\n// assertApi doesn't work for 'BigQuery.insert()'.\n\
+    // Ref: https://gtm-gear.com/posts/gtm-templates-testing/\nmock('BigQuery', ()\
+    \ => {\n  return { \n    insert: (connectionInfo, rows, options) => { \n     \
+    \ fail('BigQuery.insert should not have been called.');\n      return Promise.create((resolve,\
+    \ reject) => {\n        resolve();\n      });\n    }\n  };\n});\n\nrunCode(mockData);"
+setup: |
+  const JSON = require('JSON');
+  const Promise = require('Promise');
+
+  const requiredConsoleKeys = ['Type', 'TraceId', 'Name'];
+  const requiredBqKeys = ['timestamp', 'type', 'trace_id', 'tag_name'];
+
+
+  const expectedValue = 'test';
+  const expectedBqOptions = { ignoreUnknownValues: true };
+  const expectedPixelId = '1111111111111';
+
+  const mockData = {
+    logBigQueryProjectId: expectedValue,
+    logBigQueryDatasetId: expectedValue,
+    logBigQueryTableId: expectedValue,
+    eventType: 'custom',
+    accessToken: expectedValue,
+    pixelId: expectedPixelId,
+    eventName: expectedValue
+  };
 
 
 ___NOTES___
 
 Created on 10/11/2020, 18:14:02
-
 


### PR DESCRIPTION
Hi.

- Added support for BigQuery logging for the [GTMS-7](https://github.com/stape-io/gtm-standards/blob/main/standards/GTMS-7.md).
  - Now, the tag has only one entry point for logging, the `log` function. It receives the data in the format used by the `logToConsole` logs, and decides where to route the data to (only Console, only BigQuery, or both), based on the options the end-user chose in the template UI. It also transforms the data into the required BQ format.
- Added tests for both types of logs (Console and BigQuery).
- Updated the README.