### PR TITLE
Big Query log improvement

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,5 +1,7 @@
 homepage: "https://stape.io/"
 versions:
+  - sha: 42b92385498f21f745f0bec24d9d801a9223d7f2
+    changeNotes: Improve JSON handling for BQ logging.
   - sha: 86867d5dcc275ea314995aec8df83fc3d20ce177
     changeNotes: Add support for BigQuery logging.
   - sha: 3f0a634ab1082886bdf8667a37d99bc4a008548e

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,6 @@
 homepage: "https://stape.io/"
 versions:
-  - sha: 42b92385498f21f745f0bec24d9d801a9223d7f2
+  - sha: 4cf635cf4bf2e9d29543eb16ec2045cf1938f626
     changeNotes: Improve JSON handling for BQ logging.
   - sha: 86867d5dcc275ea314995aec8df83fc3d20ce177
     changeNotes: Add support for BigQuery logging.

--- a/template.js
+++ b/template.js
@@ -569,9 +569,17 @@ function logToBigQuery(dataToLog) {
 
   // Columns with type JSON need to be stringified.
   ['request_body', 'response_headers', 'response_body'].forEach((p) => {
-    const value = dataToLog[p];
-    // These types don't need to be stringified.
-    if (['string', 'null', 'undefined'].indexOf(getType(value)) === -1) dataToLog[p] = JSON.stringify(value);
+    // The JSON.parse of GTM Sandboxed JS should not throw and should return undefined if parsing
+    // a malformed JSON. This would be great to parse stringified objects and arrays, so that it's not needed
+    // to convert them back into their original format in BigQuery.
+    // Although it does return undefined and permits the code to continue running,
+    // it throws an error after the execution is complete, making tests and the overall execution to show as failed.
+    // Ref: https://developers.google.com/tag-platform/tag-manager/server-side/api#json
+
+    // If someday this is fixed, the lines below can be changed to this one:
+    // dataToLog[p] = JSON.stringify(JSON.parse(dataToLog[p]) || dataToLog[p]);
+
+    dataToLog[p] = JSON.stringify(dataToLog[p]);
   });
 
   // assertApi doesn't work for 'BigQuery.insert()'. It's needed to convert BigQuery into a function when testing.

--- a/template.js
+++ b/template.js
@@ -569,16 +569,8 @@ function logToBigQuery(dataToLog) {
 
   // Columns with type JSON need to be stringified.
   ['request_body', 'response_headers', 'response_body'].forEach((p) => {
-    // The JSON.parse of GTM Sandboxed JS should not throw and should return undefined if parsing
-    // a malformed JSON. This would be great to parse stringified objects and arrays, so that it's not needed
-    // to convert them back into their original format in BigQuery.
-    // Although it does return undefined and permits the code to continue running,
-    // it throws an error after the execution is complete, making tests and the overall execution to show as failed.
-    // Ref: https://developers.google.com/tag-platform/tag-manager/server-side/api#json
-
-    // If someday this is fixed, the lines below can be changed to this one:
-    // dataToLog[p] = JSON.stringify(JSON.parse(dataToLog[p]) || dataToLog[p]);
-
+    // GTM Sandboxed JSON.parse returns undefined for malformed JSON but throws post-execution, causing execution failure.
+    // If fixed, could use: dataToLog[p] = JSON.stringify(JSON.parse(dataToLog[p]) || dataToLog[p]);
     dataToLog[p] = JSON.stringify(dataToLog[p]);
   });
 

--- a/template.tpl
+++ b/template.tpl
@@ -1255,16 +1255,8 @@ function logToBigQuery(dataToLog) {
 
   // Columns with type JSON need to be stringified.
   ['request_body', 'response_headers', 'response_body'].forEach((p) => {
-    // The JSON.parse of GTM Sandboxed JS should not throw and should return undefined if parsing
-    // a malformed JSON. This would be great to parse stringified objects and arrays, so that it's not needed
-    // to convert them back into their original format in BigQuery.
-    // Although it does return undefined and permits the code to continue running,
-    // it throws an error after the execution is complete, making tests and the overall execution to show as failed.
-    // Ref: https://developers.google.com/tag-platform/tag-manager/server-side/api#json
-
-    // If someday this is fixed, the lines below can be changed to this one:
-    // dataToLog[p] = JSON.stringify(JSON.parse(dataToLog[p]) || dataToLog[p]);
-
+    // GTM Sandboxed JSON.parse returns undefined for malformed JSON but throws post-execution, causing execution failure.
+    // If fixed, could use: dataToLog[p] = JSON.stringify(JSON.parse(dataToLog[p]) || dataToLog[p]);
     dataToLog[p] = JSON.stringify(dataToLog[p]);
   });
 


### PR DESCRIPTION
Hi.

When testing, I noticed that some APIs don't return a valid string or value to insert into the BQ table.
Thus, it's required that they be passed into the `JSON.stringify` first.